### PR TITLE
Many additions

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -39,6 +39,11 @@ program
   .action(setCommand('start'))
 
 program
+  .command('inspect [path]')
+  .description('Generate dependency report')
+  .action(setCommand('inspect'))
+
+program
   .command('clean [path]')
   .description('Remove the build dir')
   .action(setCommand('clean'))

--- a/lib/cli/commands/inspect.js
+++ b/lib/cli/commands/inspect.js
@@ -1,18 +1,16 @@
 const fs = require('fs-extra')
 const path = require('path')
 const webpack = require('webpack')
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const wpConf = require('../../../webpack.config')
 
-module.exports = async function (options, log) {
-  log.info('Building for production...')
-
+module.exports = function (options, log) {
+  log.info('Generating report...')
   process.env.NODE_ENV = 'production'
   const webpackConfig = wpConf(options)
+  webpackConfig.plugins = webpackConfig.plugins || []
+  webpackConfig.plugins.push(new BundleAnalyzerPlugin())
   const compiler = webpack(webpackConfig)
-
-  const target = path.join(process.cwd(), options.dist)
-  await fs.remove(target)
-
   compiler.run(async function (err, stats) {
     if (err) return console.log(err)
     if (options.static && isDir(path.join(options.dir, options.static))) {

--- a/lib/cli/commands/start.js
+++ b/lib/cli/commands/start.js
@@ -1,6 +1,4 @@
 const path = require('path')
-const express = require('express')
-const execa = require('execa')
 const pkg = require('../../../package.json')
 const render = require('../../handle/render')
 
@@ -31,8 +29,10 @@ async function client ({ pkg, options }) {
     return // nothing to do if we're using a server component
   }
 
+  const express = require('express')
   // otherwise, this is our server that will serve up the built app
   const app = express()
+
   app.use('/client', express.static(path.join(process.cwd(), options.dist, 'client')))
   app.use('/static', express.static(path.join(process.cwd(), options.dist, options.static)))
   app.get('*', function (req, res) {
@@ -47,5 +47,6 @@ async function client ({ pkg, options }) {
 }
 
 async function server ({ pkg, options }) {
+  const execa = require('execa')
   return execa.shell(`JETPACK_ARGS="${process.argv.slice(2).join(' ')}" node ${options.server}`, { stdio: 'inherit' })
 }

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -48,9 +48,12 @@ module.exports = function options (command, program) {
     server = null
   }
 
+  const env = process.env.NODE_ENV || 'development'
+  const dist = 'dist'
+
   return clean({
     // environment
-    env: process.env.NODE_ENV || 'development',
+    env,
 
     // command we're running
     cmd: command,
@@ -77,13 +80,16 @@ module.exports = function options (command, program) {
     static: program.static || config.static || 'static',
 
     // relative path to output dist dir
-    dist: 'dist',
+    dist,
 
     // more detailed logs
     verbose: program.verbose,
 
     // url path to bundle
-    bundle: '/client/bundle.js',
+    assets: env === 'development'
+      ? ['/client/bundle.js']
+      : assets(path.join(cwd, dist, 'client')),
+
     port: program.port || config.port || 3000,
     jsx: program.jsx || config.jsx || jsx(dir),
     html: program.html || config.html,
@@ -134,5 +140,16 @@ function pkg (dir) {
     return JSON.parse(fs.readFileSync(path.join(dir, 'package.json')))
   } catch (err) {
     return { name: 'jetpack' }
+  }
+}
+
+function assets (root) {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json')))
+    return Object.keys(manifest)
+      .filter(asset => asset === 'bundle.js' || asset.endsWith('~bundle.js'))
+      .map(asset => manifest[asset])
+  } catch (err) {
+    throw new Error('Failed to read manifest.json in the build dir')
   }
 }

--- a/lib/dev/reporter.js
+++ b/lib/dev/reporter.js
@@ -62,6 +62,12 @@ const table = (array, align, splitter) => {
 }
 
 const getAssetColor = (asset, defaultColor) => {
+  if (asset.name.endsWith('.js.map') ||
+      asset.name.endsWith('.hot-update.js') ||
+      asset.name === 'manifest.json') {
+    return chalk.gray
+  }
+
   if (asset.isOverSizeLimit) {
     return chalk.yellow
   }
@@ -78,7 +84,17 @@ function printAssets (obj) {
     })
   })
 
-  if (obj.assets && obj.assets.length > 0) {
+  const assets = obj.assets
+    .sort((a, b) => {
+      return a.name > b.name ? 1 : -1
+    })
+    .sort((a, b) => {
+      const aExt = a.name.split('.')[a.name.split('.').length - 1]
+      const bExt = b.name.split('.')[b.name.split('.').length - 1]
+      return aExt > bExt ? 1 : -1
+    })
+
+  if (assets && obj.assets.length > 0) {
     const t = [
       [
         {
@@ -92,29 +108,25 @@ function printAssets (obj) {
         {
           value: 'Size',
           color: chalk.bold
-        },
-        {
-          value: '',
-          color: chalk.bold
         }
       ]
     ]
-    for (const asset of obj.assets) {
+    for (const asset of assets) {
       t.push([
         {
           value: asset.name,
-          color: getAssetColor(asset, chalk.blue)
+          color: getAssetColor(asset, chalk.white)
         },
         {
-          value: asset.chunks.reduce((acc, chunk) => acc + modules[chunk], 0),
-          color: getAssetColor(asset, chalk.white)
+          value: asset.name.endsWith('.js') && !asset.name.endsWith('.hot-update.js')
+            ? asset.chunks.reduce((acc, chunk) => acc + modules[chunk], 0)
+            : '-',
+          color: asset.name.endsWith('.js') && !asset.name.endsWith('.hot-update.js')
+            ? getAssetColor(asset, chalk.white)
+            : chalk.gray
         },
         {
           value: formatSize(asset.size),
-          color: getAssetColor(asset, chalk.white)
-        },
-        {
-          value: asset.isOverSizeLimit ? '[big]' : '',
           color: getAssetColor(asset, chalk.white)
         }
       ])

--- a/lib/dev/server.js
+++ b/lib/dev/server.js
@@ -1,11 +1,6 @@
 const path = require('path')
-const express = require('express')
-const webpack = require('webpack')
 const webpackPkg = require('webpack/package.json')
-const nodemon = require('nodemon')
 const nodemonPkg = require('nodemon/package.json')
-const webpackDevMiddleware = require('webpack-dev-middleware')
-const webpackHotMiddleware = require('webpack-hot-middleware')
 const wpConf = require('../../webpack.config')
 const pkg = require('../../package.json')
 const render = require('../handle/render')
@@ -42,6 +37,11 @@ module.exports = async function devServer (options, log) {
 }
 
 async function client ({ pkg, options, log }) {
+  const express = require('express')
+  const webpack = require('webpack')
+  const webpackDevMiddleware = require('webpack-dev-middleware')
+  const webpackHotMiddleware = require('webpack-hot-middleware')
+
   const app = express()
   const webpackConfig = wpConf(options)
   const compiler = webpack(webpackConfig)
@@ -77,10 +77,12 @@ async function client ({ pkg, options, log }) {
 }
 
 async function server ({ pkg, options, log }) {
+  const nodemon = require('nodemon')
+
   require('nodemon/lib/utils').log.required(false)
 
   const app = nodemon({
-    exec: `JETPACK_ARGS="${process.argv.slice(2).join(' ')}"" node ${options.server}`,
+    exec: `JETPACK_ARGS="${process.argv.slice(2).join(' ')}" node ${options.server}`,
     ext: 'js json yml',
     ignore: options.client,
     quiet: true

--- a/lib/handle/handle.js
+++ b/lib/handle/handle.js
@@ -14,21 +14,29 @@ const render = require('./render')
 let options
 let serve
 
-module.exports = function handle (req, res, next = () => {}) {
-  if (!options) {
-    options = cli.options()
-    if (options.env !== 'development' || options.cmd === 'start') {
-      serve = createServe(path.join(process.cwd(), options.dist))
+module.exports = async function handle (req, res, next) {
+  try {
+    if (!options) {
+      options = cli.options()
+      if (options.env !== 'development' || options.cmd === 'start') {
+        serve = createServe(path.join(process.cwd(), options.dist))
+      }
     }
-  }
 
-  if (req.path.startsWith('/client/')) {
-    if (serve) {
-      serve(req, res, next)
+    if (req.path.startsWith('/client/')) {
+      if (serve) {
+        serve(req, res, next)
+      } else {
+        proxy(req, res, `http://localhost:${options.port + 1}`)
+      }
     } else {
-      proxy(req, res, `http://localhost:${options.port + 1}`)
+      send(req, res, render(options))
     }
-  } else {
-    send(req, res, render(options))
+  } catch (err) {
+    if (next) {
+      next(err)
+    } else {
+      throw err
+    }
   }
 }

--- a/lib/handle/render.js
+++ b/lib/handle/render.js
@@ -24,7 +24,9 @@ module.exports = function render (options) {
       </head>
       <body>
         <div id='root'></div>
-        <script type='text/javascript' src='${options.bundle}'></script>
+        ${options.assets.map(asset =>
+          `<script type='text/javascript' src='${asset}'></script>`
+        ).join('\n')}
       </body>
     </html>
   `

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0-beta.40",
+    "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta.40",
     "@babel/preset-env": "^7.0.0-beta.40",
     "@babel/preset-react": "^7.0.0-beta.40",
     "autoprefixer": "^6.7.6",
@@ -41,8 +42,10 @@
     "send": "^0.16.2",
     "style-loader": "^0.20.2",
     "webpack": "^4.0.0",
+    "webpack-bundle-analyzer": "^2.11.1",
     "webpack-dev-middleware": "^3.0.0",
-    "webpack-hot-middleware": "^2.21.0"
+    "webpack-hot-middleware": "^2.21.0",
+    "webpack-manifest-plugin": "^2.0.0-rc.2"
   },
   "devDependencies": {
     "mocha": "^4.1.0",

--- a/test/cli/options.test.js
+++ b/test/cli/options.test.js
@@ -9,7 +9,7 @@ const base = (pkg, extra = {}) => Object.assign({
   cmd: 'dev',
   owd: dir('fixtures', pkg),
   dir: dir('fixtures', pkg),
-  bundle: '/client/bundle.js',
+  assets: ['/client/bundle.js'],
   client: '.',
   clientDisabled: false,
   server: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,6 +211,10 @@
   version "7.0.0-beta.40"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.40.tgz#6c45889569add3b3721cc9a481ae99906f240874"
 
+"@babel/plugin-syntax-dynamic-import@^7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.40.tgz#5d9b58d4fbe1dfabbd44dee2eb267c466d7e9b87"
+
 "@babel/plugin-syntax-jsx@7.0.0-beta.40":
   version "7.0.0-beta.40"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.40.tgz#db44d52ff06f784be22f2659e694cc2cf97f99f9"
@@ -506,7 +510,7 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.0.0:
+acorn@^5.0.0, acorn@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.0.tgz#1abb587fbf051f94e3de20e6b26ef910b1828298"
 
@@ -890,6 +894,10 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -966,6 +974,14 @@ bcrypt-pbkdf@^1.0.0:
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
   dependencies:
     tweetnacl "^0.14.3"
+
+bfj-node4@^5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bfj-node4/-/bfj-node4-5.2.1.tgz#3a6aa2730cf6911ba2afb836c2f88f015d718f3f"
+  dependencies:
+    bluebird "^3.5.1"
+    check-types "^7.3.0"
+    tryer "^1.0.0"
 
 big.js@^3.1.3:
   version "3.2.0"
@@ -1249,6 +1265,10 @@ chalk@^2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+check-types@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/check-types/-/check-types-7.3.0.tgz#468f571a4435c24248f5fd0cb0e8d87c3c341e7d"
+
 choices-separator@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/choices-separator/-/choices-separator-2.0.0.tgz#92fd1763182d79033f5c5c51d0ba352e5567c696"
@@ -1403,7 +1423,7 @@ commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
-commander@^2.9.0:
+commander@^2.13.0, commander@^2.9.0:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
 
@@ -1846,7 +1866,7 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
-duplexer@~0.1.1:
+duplexer@^0.1.1, duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
@@ -1868,6 +1888,10 @@ ecc-jsbn@~0.1.1:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+ejs@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
 electron-releases@^2.1.0:
   version "2.1.0"
@@ -2258,7 +2282,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-express@^4.15.2:
+express@^4.15.2, express@^4.16.2:
   version "4.16.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"
   dependencies:
@@ -2370,6 +2394,10 @@ file-entry-cache@^2.0.0:
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+
+filesize@^3.5.11:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.0.tgz#22d079615624bb6fd3c04026120628a41b3f4efa"
 
 fill-range@^2.1.0:
   version "2.2.3"
@@ -2507,6 +2535,16 @@ from2@^2.1.0:
 from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+
+fs-extra@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    klaw "^1.0.0"
+    path-is-absolute "^1.0.0"
+    rimraf "^2.2.8"
 
 fs-extra@^5.0.0:
   version "5.0.0"
@@ -2670,13 +2708,20 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
 growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
+
+gzip-size@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-4.1.0.tgz#8ae096257eabe7d69c45be2b67c448124ffb517c"
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^3.0.0"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -3259,6 +3304,12 @@ json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+jsonfile@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -3305,6 +3356,12 @@ kind-of@^5.0.0, kind-of@^5.0.2:
 kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+
+klaw@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
+  optionalDependencies:
+    graceful-fs "^4.1.9"
 
 koalas@^1.0.2:
   version "1.0.2"
@@ -3373,13 +3430,13 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
+"lodash@>=3.5 <5", lodash@^4.17.4, lodash@^4.2.0:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
 lodash@^4.0.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@^4.2.0:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 log-ok@^0.1.1:
   version "0.1.1"
@@ -3864,6 +3921,10 @@ once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
 onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+
+opener@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
 optionator@^0.8.2:
   version "0.8.2"
@@ -5461,6 +5522,10 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+tryer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.0.tgz#027b69fa823225e551cace3ef03b11f6ab37c1d7"
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -5706,6 +5771,23 @@ watchpack@^1.4.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
+webpack-bundle-analyzer@^2.11.1:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.11.1.tgz#b9fbfb6a32c0a8c1c3237223e90890796b950ab9"
+  dependencies:
+    acorn "^5.3.0"
+    bfj-node4 "^5.2.0"
+    chalk "^2.3.0"
+    commander "^2.13.0"
+    ejs "^2.5.7"
+    express "^4.16.2"
+    filesize "^3.5.11"
+    gzip-size "^4.1.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    opener "^1.4.3"
+    ws "^4.0.0"
+
 webpack-dev-middleware@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.0.0.tgz#ae8902596f1b1fa8f7eada874aabb64cba9cd53e"
@@ -5735,6 +5817,13 @@ webpack-log@^1.0.1:
     log-symbols "^2.1.0"
     loglevelnext "^1.0.1"
     uuid "^3.1.0"
+
+webpack-manifest-plugin@^2.0.0-rc.2:
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.0-rc.2.tgz#7e12abb805795fe256b085a214a15d9568f0e692"
+  dependencies:
+    fs-extra "^0.30.0"
+    lodash ">=3.5 <5"
 
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"
@@ -5824,6 +5913,13 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
+
+ws@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-4.1.0.tgz#a979b5d7d4da68bf54efe0408967c324869a7289"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- inspect command
- sort asset list in dev output
- split chunks in prod, produce manifest.json and use that in render
- also start using [chunkname] in the prod output
- build cleans up and logs faster
- load some module deps lazily to speed things up
- catch errors in handle and forward to next