### PR TITLE
Fix bug resolving React modules using exports syntax

### DIFF
--- a/lib/webpack.hot.js
+++ b/lib/webpack.hot.js
@@ -38,7 +38,7 @@ module.exports = (config, options) => {
 
 function isUsingReact(dir) {
   try {
-    return requireRelative.resolve('react', dir)
+    return requireRelative.resolve('react', dir).replace(/\/index.js$/, '')
   } catch (err) {
     if (err.code !== 'MODULE_NOT_FOUND') {
       throw err
@@ -49,7 +49,7 @@ function isUsingReact(dir) {
 
 function isUsingReactDOM(dir) {
   try {
-    return requireRelative.resolve('react-dom', dir)
+    return requireRelative.resolve('react-dom', dir).replace(/\/index.js$/, '')
   } catch (err) {
     if (err.code !== 'MODULE_NOT_FOUND') {
       throw err


### PR DESCRIPTION
`import { createRoot } from 'react-dom/client'`

would error with:
`Parsed request is a module
    using description file: /Users/mattliv/humaans/humaans/package.json (relative path: ./app/client/core)
      aliased with mapping 'react-dom': '/Users/mattliv/humaans/humaans/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/index.js' to '/Users/mattliv/humaans/humaans/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/index.js/client'`

because `require-relative` package doesn't know how to correctly map browser exports 