### PR TITLE
make runtimeChunk more CSP-friendly by not inlining

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -69,7 +69,7 @@ async function createConfig(options, log) {
     config.output.chunkFilename = config.output.chunkFilename.replace('[name].', '[name].[contenthash].')
     config.output.publicPath = options.publicPath
     config.optimization.splitChunks = { chunks: 'all' }
-    config.optimization.runtimeChunk = true
+    config.optimization.runtimeChunk = 'single'
     config.optimization.usedExports = true
   }
 


### PR DESCRIPTION
This makes the runtime chunk more CSP-friendly by externalising it like the other assets instead of inlining, so it can be allowed by a CSP that allows same-origin scripts (and without unsafe-inline/nonce)

**Before (runtime script inlined)**
![Screenshot 2022-08-16 at 11 53 04](https://user-images.githubusercontent.com/1136009/184862792-801cb561-da6e-4d1d-b548-277095e93c10.png)

**After (runtime script is its own file)**
![Screenshot 2022-08-16 at 11 49 00](https://user-images.githubusercontent.com/1136009/184862836-2e761eeb-c4aa-4ca5-91ae-8613190c3390.png)

