### PR TITLE
Correctly parse config option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,7 +19,7 @@ program
   .arguments('[path]')
   .option('-p, --port <n>', 'port, defaults to 3030', Number)
   .option('-d, --dir [path]', 'run jetpack in the context of this directory')
-  .option('-c, --config', 'config file to use, defaults to jetpack.config.js')
+  .option('-c, --config [path]', 'config file to use, defaults to jetpack.config.js')
   .option('-r, --no-hot', 'disable hot reloading', null)
   .option('-u, --no-minify', 'disable minification', null)
   .option('-m, --modern', 'build a modern bundle')


### PR DESCRIPTION
As per title.

Passing `--config` or `-c` was incorrectly setting `config: true` rather than the given string.