### PR TITLE
Support jetpack.config.cjs config file

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const requireRelative = require('require-relative')
 
-const CONFIG_FILE = 'jetpack.config.js'
+const SUPPORTED_CONFIG_FILES = ['jetpack.config.js', 'jetpack.config.cjs']
 
 module.exports = function options(command = 'dev', program = {}) {
   const args = program.args || []
@@ -25,7 +25,9 @@ module.exports = function options(command = 'dev', program = {}) {
     process.env.NODE_ENV = 'production'
   }
 
-  const configFromFile = readConfigFromFile(dir, opts.config || CONFIG_FILE)
+  const configPath = opts.config || SUPPORTED_CONFIG_FILES.find((file) => fs.pathExistsSync(path.join(dir, file)))
+
+  const configFromFile = readConfigFromFile(dir, configPath)
   const options = Object.assign(
     {},
     configFromFile,
@@ -105,8 +107,8 @@ module.exports = function options(command = 'dev', program = {}) {
           ? undefined
           : 'source-map'
         : options.sourceMaps === true
-        ? 'source-map'
-        : options.sourceMaps,
+          ? 'source-map'
+          : options.sourceMaps,
 
     // to turn off minification in production
     minify: options.minify === undefined ? true : options.minify,
@@ -184,6 +186,7 @@ function clean(obj) {
 }
 
 function readConfigFromFile(dir, configFilePath) {
+  if (!configFilePath) return {}
   const configPath = path.join(dir, configFilePath)
   const exists = fs.pathExistsSync(configPath)
   return exists ? require(configPath) : {}


### PR DESCRIPTION
Allows running jetpack in ESM codebases.