### PR TITLE
Fix proxy crash when headers already sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.4.2
+
+- Fix proxy error handling when headers have already been sent
+
 # 4.4.1
 
 - Fix Firefox HMR warning

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -17,10 +17,22 @@ module.exports = (target, log) => (req, res) => {
     params: req.params,
     session: req.session
   }
+  const sendProxyError = (statusCode, body) => {
+    if (res.headersSent || res.writableEnded) {
+      return
+    }
+    res.status(statusCode)
+    res.send(body)
+  }
+
   const proxyReq = http.request(reqOpt, function (proxyRes) {
-    proxyRes.pipe(res)
+    if (res.headersSent || res.writableEnded) {
+      proxyRes.resume()
+      return
+    }
     res.status(proxyRes.statusCode)
     Object.keys(proxyRes.headers).forEach((header) => res.set(header, proxyRes.headers[header]))
+    proxyRes.pipe(res)
   })
 
   proxyReq.setTimeout(30000, function () {
@@ -32,12 +44,10 @@ module.exports = (target, log) => (req, res) => {
   proxyReq.on('error', function (err) {
     if (err.message === 'Request timeout') {
       log.error(`Proxy request to ${target} timed out`)
-      res.status(504)
-      res.send({ error: 'Request timeout' })
+      sendProxyError(504, { error: 'Request timeout' })
     } else {
       log.error(`Failed to proxy ${req.url} to ${target}:`, err.message)
-      res.status(502)
-      res.send({ error: err })
+      sendProxyError(502, { error: err })
     }
   })
 }

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -42,7 +42,19 @@ function createProxy(target) {
         params: req.params,
         session: req.session
       }
+      const sendProxyError = (statusCode, headers, body) => {
+        if (res.headersSent || res.writableEnded) {
+          return
+        }
+        res.writeHead(statusCode, headers)
+        res.end(body)
+      }
+
       const proxyReq = http.request(reqOpt, function (proxyRes) {
+        if (res.headersSent || res.writableEnded) {
+          proxyRes.resume()
+          return
+        }
         res.writeHead(proxyRes.statusCode, proxyRes.headers)
         proxyRes.pipe(res)
       })
@@ -60,24 +72,27 @@ function createProxy(target) {
           if (acceptHeader.includes('text/html')) {
             const html = await errorHtmlPromise
             if (html) {
-              res.writeHead(502, { 'Content-Type': 'text/html' })
-              res.end(html)
+              sendProxyError(502, { 'Content-Type': 'text/html' }, html)
             } else {
-              res.writeHead(502, { 'Content-Type': 'text/html' })
-              res.end('<!DOCTYPE html><h1>jetpack not running</h1><p>Failed to connect to the jetpack dev server.</p>')
+              sendProxyError(
+                502,
+                { 'Content-Type': 'text/html' },
+                '<!DOCTYPE html><h1>jetpack not running</h1><p>Failed to connect to the jetpack dev server.</p>'
+              )
             }
           } else {
-            res.writeHead(502, { 'Content-Type': 'application/json' })
-            res.end(JSON.stringify({ error: msg }))
+            sendProxyError(502, { 'Content-Type': 'application/json' }, JSON.stringify({ error: msg }))
           }
         } else if (err.message === 'Request timeout') {
           console.error(chalk.red('[jetpack] Proxy request timed out'))
-          res.writeHead(504, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ error: 'Proxy request timed out' }))
+          sendProxyError(
+            504,
+            { 'Content-Type': 'application/json' },
+            JSON.stringify({ error: 'Proxy request timed out' })
+          )
         } else {
           console.log(err)
-          res.writeHead(502, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ error: err.stack }))
+          sendProxyError(502, { 'Content-Type': 'application/json' }, JSON.stringify({ error: err.stack }))
         }
       })
 


### PR DESCRIPTION
## Summary

- Guard against writing to the response after headers have been sent or the response has ended
- Fixes a race condition where the proxy response callback and error handler could both attempt to write to the same response, causing ERR_HTTP_HEADERS_SENT crashes
- Fix ordering in lib/proxy.js to set status and headers before piping the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)